### PR TITLE
feat: Added managed storage KMS configuration

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -40,6 +40,15 @@ resource "aws_ecs_cluster" "this" {
           }
         }
       }
+
+      dynamic "managed_storage_configuration" {
+        for_each = try([configuration.value.managed_storage_configuration], [{}])
+
+        content {
+          kms_key_id                           = try(managed_storage_configuration.value.kms_key_id, null)
+          fargate_ephemeral_storage_kms_key_id = try(managed_storage_configuration.value.fargate_ephemeral_storage_kms_key_id, null)
+        }
+      }
     }
   }
 
@@ -65,6 +74,15 @@ resource "aws_ecs_cluster" "this" {
               s3_key_prefix                  = try(log_configuration.value.s3_key_prefix, null)
             }
           }
+        }
+      }
+
+      dynamic "managed_storage_configuration" {
+        for_each = try([configuration.value.managed_storage_configuration], [{}])
+
+        content {
+          kms_key_id                           = try(managed_storage_configuration.value.kms_key_id, null)
+          fargate_ephemeral_storage_kms_key_id = try(managed_storage_configuration.value.fargate_ephemeral_storage_kms_key_id, null)
         }
       }
     }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.66.1"
+      version = ">= 5.59.0"
     }
   }
 }


### PR DESCRIPTION
# Summary

Added ephemeral kms configuration.

### co-pilot summary
This pull request includes updates to the Terraform configuration for an AWS ECS cluster. The changes focus on adding dynamic managed storage configurations and updating the required AWS provider version.

Key changes include:

* Added dynamic `managed_storage_configuration` block to the `aws_ecs_cluster` resource to handle managed storage settings. (`modules/cluster/main.tf` [[1]](diffhunk://#diff-b573a5884d86152370a746aac6beaf1185c25ac13f5eb95dfc28264356b6d595R43-R51) [[2]](diffhunk://#diff-b573a5884d86152370a746aac6beaf1185c25ac13f5eb95dfc28264356b6d595R79-R87)
* Updated the required AWS provider version to `>= 5.59.0` in the `versions.tf` file. (`versions.tf` [versions.tfL7-R7](diffhunk://#diff-dfd5848fa77a04d0343891fe859286cc210473d10f0e62c7f99f0d5ecf1a9927L7-R7))